### PR TITLE
Fix broken lit furnace textures

### DIFF
--- a/src/main/resources/assets/foxfurnace/blockstates/copper_furnace.json
+++ b/src/main/resources/assets/foxfurnace/blockstates/copper_furnace.json
@@ -27,7 +27,7 @@
       "y": 270
     },
     "facing=west,lit=true": {
-      "model": "foxfurnace:block/copper_copper_furnace_on",
+      "model": "foxfurnace:block/copper_furnace_on",
       "y": 270
     }
   }

--- a/src/main/resources/assets/foxfurnace/blockstates/diamond_furnace.json
+++ b/src/main/resources/assets/foxfurnace/blockstates/diamond_furnace.json
@@ -27,7 +27,7 @@
       "y": 270
     },
     "facing=west,lit=true": {
-      "model": "foxfurnace:block/diamond_diamond_furnace_on",
+      "model": "foxfurnace:block/diamond_furnace_on",
       "y": 270
     }
   }

--- a/src/main/resources/assets/foxfurnace/blockstates/emerald_furnace.json
+++ b/src/main/resources/assets/foxfurnace/blockstates/emerald_furnace.json
@@ -27,7 +27,7 @@
       "y": 270
     },
     "facing=west,lit=true": {
-      "model": "foxfurnace:block/emerald_emerald_furnace_on",
+      "model": "foxfurnace:block/emerald_furnace_on",
       "y": 270
     }
   }

--- a/src/main/resources/assets/foxfurnace/blockstates/gold_furnace.json
+++ b/src/main/resources/assets/foxfurnace/blockstates/gold_furnace.json
@@ -27,7 +27,7 @@
       "y": 270
     },
     "facing=west,lit=true": {
-      "model": "foxfurnace:block/gold_gold_furnace_on",
+      "model": "foxfurnace:block/gold_furnace_on",
       "y": 270
     }
   }

--- a/src/main/resources/assets/foxfurnace/blockstates/iron_furnace.json
+++ b/src/main/resources/assets/foxfurnace/blockstates/iron_furnace.json
@@ -27,7 +27,7 @@
       "y": 270
     },
     "facing=west,lit=true": {
-      "model": "foxfurnace:block/iron_iron_furnace_on",
+      "model": "foxfurnace:block/iron_furnace_on",
       "y": 270
     }
   }

--- a/src/main/resources/assets/foxfurnace/blockstates/netherite_furnace.json
+++ b/src/main/resources/assets/foxfurnace/blockstates/netherite_furnace.json
@@ -27,7 +27,7 @@
       "y": 270
     },
     "facing=west,lit=true": {
-      "model": "foxfurnace:block/netherite_netherite_furnace_on",
+      "model": "foxfurnace:block/netherite_furnace_on",
       "y": 270
     }
   }


### PR DESCRIPTION
There are typos currently resulting in missing textures for every lit furnace added by the mod.